### PR TITLE
Update safe-logging-go to v0.4.0

### DIFF
--- a/godel/config/dist-plugin.yml
+++ b/godel/config/dist-plugin.yml
@@ -22,7 +22,7 @@ products:
               path: "{{ProjectDir}}"
             - module: github.com/palantir/safe-logging-go
               import: github.com/palantir/safe-logging-go/golangcilint/safelogging
-              version: v0.2.0
+              version: v0.4.0
     publish: {}
   golangci-lint-palantir-config:
     dist:


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Updates safe-logging-go to v0.4.0.

Fixes issue that prevented linter configuration to load in golangci-lint.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

