### PR TITLE
Update plugin config to ignore experimental govet inline analyzer warning

### DIFF
--- a/pluginconfig/golangci.yml
+++ b/pluginconfig/golangci.yml
@@ -22,5 +22,12 @@ linters:
     - unconvert
     - unused
 
+  exclusions:
+    rules:
+      # ignores a warning produced by the experimental govet inline analyzer
+      - text: "inline: cannot inline: type parameter inference is not yet supported"
+        linters:
+          - govet
+
 run:
   relative-path-mode: gomod


### PR DESCRIPTION

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
golangci-lint-palantir-config: adds an exclusion rule for the "govet" linter that ignores/excludes issues with the text "inline: cannot inline: type parameter inference is not yet supported".
==COMMIT_MSG==

Errors of this form are effectively warnings that state that a line of code that uses generics but does not explicitly list the types cannot be analyzed for inlining. Because this is strictly an optimization, ignoring the issue as baseline configuration is acceptable.

Note that, with the current merge semantics, there is no way to "undo" this base configuration: because user-provided exclusions are appended to the base configuration, there is no way to remove an entry that is already there. A project that wants to remove this exclusion would need to specify their own base configuration.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

